### PR TITLE
Refactoring of event handlers

### DIFF
--- a/dist/src/Main.js
+++ b/dist/src/Main.js
@@ -119,73 +119,98 @@ class Main {
         }, 500);
         this.strTableManager.renderNumberInput(stringMin, stringMax, stringDefault);
         this.renderStringTable('str-table', 'num-strings');
-        // TODO: Works, but is pretty ugly and should be refactored. This is a repetition of an onchange event handler that
-        //       is used in runTime(), which itself no longer points to the original element after it is removed from the DOM.
-        const numStrings = document.getElementById('num-strings');
-        const caller = this;
-        numStrings.onchange = function () {
-            for (let i = 0; i < caller.strTableManager.stringTables.length; i++) {
-                if (caller.strTableManager.stringTables[i].isCurrent) {
-                    caller.renderStringTable('str-table', 'num-strings');
-                }
-            }
-        };
+        this.handleNumberOfStringsInputOnChange();
     }
     /**
-     * Run time!
+     * Handle change in the input that modifies the number of strings displayed.
      */
-    runTime() {
-        const caller = this;
-        // Render our input (type 'number') first
-        if (!document.getElementsByClassName('number-of-strings')[0]) {
-            caller.strTableManager.renderNumberInput();
-        }
-        // Some of our elements to be used
+    handleNumberOfStringsInputOnChange() {
         const numberOfStringsInput = document.getElementById('num-strings');
-        const buttonAddCustomStrings = document.getElementsByClassName('add-custom-strings')[0];
-        const buttonPitchDown = document.getElementsByClassName('button-pitches-decrease')[0];
-        const buttonPitchUp = document.getElementsByClassName('button-pitches-increase')[0];
-        // Events
-        numberOfStringsInput.onchange = function () {
-            for (let i = 0; i < caller.strTableManager.stringTables.length; i++) {
-                if (caller.strTableManager.stringTables[i].isCurrent) {
-                    caller.renderStringTable('str-table', 'num-strings');
+        numberOfStringsInput.onchange = (() => {
+            for (let i = 0; i < this.strTableManager.stringTables.length; i++) {
+                if (this.strTableManager.stringTables[i].isCurrent) {
+                    this.renderStringTable('str-table', 'num-strings');
                 }
             }
-        };
-        buttonPitchDown.onclick = function () {
-            caller.renderPitchShifts(-1);
-        };
-        buttonPitchUp.onclick = function () {
-            caller.renderPitchShifts(1);
-        };
-        buttonAddCustomStrings.onclick = function () {
+        }).bind(this);
+    }
+    /**
+     * Handle click on the button to pitch down.
+     */
+    handlePitchDownButtonOnClick() {
+        const buttonPitchDown = document.getElementsByClassName('button-pitches-decrease')[0];
+        buttonPitchDown.onclick = (() => {
+            this.renderPitchShifts(-1);
+        }).bind(this);
+    }
+    /**
+     * Handle click on the button to pitch up.
+     */
+    handlePitchUpButtonOnClick() {
+        const buttonPitchUp = document.getElementsByClassName('button-pitches-increase')[0];
+        buttonPitchUp.onclick = (() => {
+            this.renderPitchShifts(1);
+        }).bind(this);
+    }
+    /**
+     * Handle click for the custom instrument string submission.
+     */
+    handleCustomStringSubmit() {
+        const customSubmit = document.getElementsByClassName('submit')[0];
+        if (customSubmit) {
+            customSubmit.onclick = (() => {
+                this.submitCustomStringData();
+            }).bind(this);
+        }
+    }
+    /**
+     * Handle click for the custom instrument string interface exit.
+     */
+    handleCustomStringExit() {
+        const customExit = document.getElementsByClassName('exit')[0];
+        if (customExit) {
+            customExit.onclick = (() => {
+                const overlay = document.getElementsByClassName('overlay')[0];
+                overlay.classList.replace('show', 'hide');
+                setTimeout(() => {
+                    overlay.style.display = 'none';
+                }, 500);
+            });
+        }
+    }
+    /**
+     * Handle click on the button to add custom user-defined instrument strings.
+     */
+    handleAddCustomStringsButtonOnClick() {
+        const buttonAddCustomStrings = document.getElementsByClassName('add-custom-strings')[0];
+        buttonAddCustomStrings.onclick = (() => {
             const overlay = document.getElementsByClassName('overlay')[0];
             if (overlay) {
                 overlay.style.display = 'block';
                 overlay.classList.replace('hide', 'show');
             }
             else {
-                caller.renderStringCustomInput();
+                this.renderStringCustomInput();
             }
-            // Watch for click on exit or submit
-            const customSubmit = document.getElementsByClassName('submit')[0];
-            const customExit = document.getElementsByClassName('exit')[0];
-            if (customSubmit) {
-                customSubmit.onclick = function () {
-                    caller.submitCustomStringData();
-                };
-            }
-            if (customExit) {
-                customExit.onclick = function () {
-                    const overlay = document.getElementsByClassName('overlay')[0];
-                    overlay.classList.replace('show', 'hide');
-                    setTimeout(() => {
-                        overlay.style.display = 'none';
-                    }, 500);
-                };
-            }
-        };
-        caller.renderStringTable('str-table', 'num-strings');
+            // Handle clicks on submit or exit
+            this.handleCustomStringSubmit();
+            this.handleCustomStringExit();
+        }).bind(this);
+    }
+    /**
+     * Run time!
+     */
+    run() {
+        // Render our input of type number first
+        if (!document.getElementsByClassName('number-of-strings')[0]) {
+            this.strTableManager.renderNumberInput();
+        }
+        // Event handlers
+        this.handleNumberOfStringsInputOnChange();
+        this.handlePitchDownButtonOnClick();
+        this.handlePitchUpButtonOnClick();
+        this.handleAddCustomStringsButtonOnClick();
+        // Table render
+        this.renderStringTable('str-table', 'num-strings');
     }
 }

--- a/dist/src/Main.js
+++ b/dist/src/Main.js
@@ -89,7 +89,7 @@ class Main {
                 weightsArray.push(Number(weightValue));
             }
         }
-        for (let i = 0; i < gaugeArray.length; ++i) {
+        for (let i = 0; i < weightsArray.length; ++i) {
             if (gaugeArray[i] && weightsArray[i]) {
                 stringObjects.push({ "gauge": gaugeArray[i], "unitWeight": weightsArray[i] });
             }
@@ -102,6 +102,7 @@ class Main {
         stringMax = stringObjects.length;
         stringMin = 1;
         stringDefault = stringMax > 6 ? 6 : stringMax;
+        // Push each new StringInfo object
         for (let i = 0; i < stringObjects.length; i++) {
             stringCustomInfoArray.push(new StringInfo(stringObjects[i].gauge, stringObjects[i].unitWeight, stringBrandValue, stringTypeValue));
         }
@@ -122,12 +123,12 @@ class Main {
         }, 500);
         this.strTableManager.renderNumberInput(stringMin, stringMax, stringDefault);
         this.renderStringTable('str-table', 'num-strings');
-        this.handleNumberOfStringsInputOnChange();
+        this.onChangeInputNumberOfStrings();
     }
     /**
-     * Handle change in the input that modifies the number of strings displayed.
+     * Handles change that modifies the number of strings displayed.
      */
-    handleNumberOfStringsInputOnChange() {
+    onChangeInputNumberOfStrings() {
         const tables = this.strTableManager.stringTables;
         const numberOfStringsInput = document.getElementById('num-strings');
         numberOfStringsInput.onchange = (() => {
@@ -139,27 +140,27 @@ class Main {
         }).bind(this);
     }
     /**
-     * Handle click on the button to pitch down.
+     * Handles click to pitch all strings down.
      */
-    handlePitchDownButtonOnClick() {
-        const buttonPitchDown = document.getElementsByClassName('button-pitches-decrease')[0];
-        buttonPitchDown.onclick = (() => {
+    onClickButtonPitchesDown() {
+        const buttonPitchesDown = document.getElementsByClassName('button-pitches-decrease')[0];
+        buttonPitchesDown.onclick = (() => {
             this.renderPitchShifts(-1);
         }).bind(this);
     }
     /**
-     * Handle click on the button to pitch up.
+     * Handles click to pitch all strings up.
      */
-    handlePitchUpButtonOnClick() {
-        const buttonPitchUp = document.getElementsByClassName('button-pitches-increase')[0];
-        buttonPitchUp.onclick = (() => {
+    onClickButtonPitchesUp() {
+        const buttonPitchesUp = document.getElementsByClassName('button-pitches-increase')[0];
+        buttonPitchesUp.onclick = (() => {
             this.renderPitchShifts(1);
         }).bind(this);
     }
     /**
-     * Handle click for the custom instrument string submission.
+     * Handles click for the custom instrument string submission.
      */
-    handleCustomStringSubmit() {
+    onClickSubmitCustomString() {
         const customSubmit = document.getElementsByClassName('submit')[0];
         if (customSubmit) {
             customSubmit.onclick = (() => {
@@ -168,9 +169,9 @@ class Main {
         }
     }
     /**
-     * Handle click for the custom instrument string interface exit.
+     * Handles click for the custom instrument string interface exit.
      */
-    handleCustomStringExit() {
+    onClickExitCustomString() {
         const customExit = document.getElementsByClassName('exit')[0];
         if (customExit) {
             customExit.onclick = (() => {
@@ -183,9 +184,9 @@ class Main {
         }
     }
     /**
-     * Handle click on the button to add custom user-defined instrument strings.
+     * Handles button click to add custom user-defined instrument strings.
      */
-    handleAddCustomStringsButtonOnClick() {
+    onClickButtonAddCustomStrings() {
         const buttonAddCustomStrings = document.getElementsByClassName('add-custom-strings')[0];
         buttonAddCustomStrings.onclick = (() => {
             const overlay = document.getElementsByClassName('overlay')[0];
@@ -197,8 +198,8 @@ class Main {
                 this.renderStringCustomInput();
             }
             // Handle clicks on submit or exit
-            this.handleCustomStringSubmit();
-            this.handleCustomStringExit();
+            this.onClickSubmitCustomString();
+            this.onClickExitCustomString();
         }).bind(this);
     }
     /**
@@ -210,10 +211,10 @@ class Main {
             this.strTableManager.renderNumberInput();
         }
         // Event handlers
-        this.handleNumberOfStringsInputOnChange();
-        this.handlePitchDownButtonOnClick();
-        this.handlePitchUpButtonOnClick();
-        this.handleAddCustomStringsButtonOnClick();
+        this.onChangeInputNumberOfStrings();
+        this.onClickButtonPitchesDown();
+        this.onClickButtonPitchesUp();
+        this.onClickButtonAddCustomStrings();
         // Table render
         this.renderStringTable('str-table', 'num-strings');
     }

--- a/dist/src/Main.js
+++ b/dist/src/Main.js
@@ -37,12 +37,13 @@ class Main {
      * @param {number} semitones A semitone count.
      */
     renderPitchShifts(semitones) {
-        for (let i = 0; i < this.strTableManager.stringTables.length; i++) {
-            if (this.strTableManager.stringTables[i].isCurrent) {
-                this.strTableManager.stringTables[i].shiftPitches(semitones);
-                this.strTableManager.stringTables[i].render('str-table');
+        const tables = this.strTableManager.stringTables;
+        tables.forEach((table, i) => {
+            if (table.isCurrent) {
+                tables[i].shiftPitches(semitones);
+                tables[i].render('str-table');
             }
-        }
+        });
     }
     /**
      * Clears the old table and re-renders a new one.
@@ -51,18 +52,20 @@ class Main {
      * @param {string} numberId The id for the `Number of Strings` input element.
      */
     renderStringTable(tableId, numberId) {
-        let numStrings = document.getElementById(numberId).value;
-        for (let i = 0; i < this.strTableManager.stringTables.length; i++) {
-            if (this.strTableManager.stringTables[i].isCurrent) {
-                this.strTableManager.stringTables[i].setNumStrings(Number(numStrings));
-                this.strTableManager.stringTables[i].render(tableId);
+        const tables = this.strTableManager.stringTables;
+        const numStrings = document.getElementById(numberId).value;
+        tables.forEach((table, i) => {
+            if (table.isCurrent) {
+                tables[i].setNumStrings(Number(numStrings));
+                tables[i].render(tableId);
             }
-        }
+        });
     }
     /**
      * Submit function for the custom string data.
      */
     submitCustomStringData() {
+        const tables = this.strTableManager.stringTables;
         const overlay = document.getElementsByClassName('overlay')[0];
         const stringBrandValue = document.getElementsByClassName('custom-string-brand')[0].value;
         const stringTypeValue = document.getElementsByClassName('custom-string-type')[0].value;
@@ -103,15 +106,15 @@ class Main {
             stringCustomInfoArray.push(new StringInfo(stringObjects[i].gauge, stringObjects[i].unitWeight, stringBrandValue, stringTypeValue));
         }
         // Push a new string table
-        this.strTableManager.stringTables.push(new StringTable(StringManager.getInstance().getStandardTuning(stringCustomInfoArray)));
+        tables.push(new StringTable(StringManager.getInstance().getStandardTuning(stringCustomInfoArray)));
         // Set the new string table as the current
-        for (let i = 0; i < this.strTableManager.stringTables.length; i++) {
-            if (i === this.strTableManager.stringTables.length - 1) {
-                this.strTableManager.stringTables[i].canModifyGauge = false;
-                this.strTableManager.stringTables[i].isCurrent = true;
+        for (let i = 0; i < tables.length; i++) {
+            if (i === tables.length - 1) {
+                tables[i].canModifyGauge = false;
+                tables[i].isCurrent = true;
                 continue;
             }
-            this.strTableManager.stringTables[i].isCurrent = false;
+            tables[i].isCurrent = false;
         }
         overlay.classList.replace('show', 'hide');
         setTimeout(() => {
@@ -125,10 +128,11 @@ class Main {
      * Handle change in the input that modifies the number of strings displayed.
      */
     handleNumberOfStringsInputOnChange() {
+        const tables = this.strTableManager.stringTables;
         const numberOfStringsInput = document.getElementById('num-strings');
         numberOfStringsInput.onchange = (() => {
-            for (let i = 0; i < this.strTableManager.stringTables.length; i++) {
-                if (this.strTableManager.stringTables[i].isCurrent) {
+            for (let i = 0; i < tables.length; i++) {
+                if (tables[i].isCurrent) {
                     this.renderStringTable('str-table', 'num-strings');
                 }
             }

--- a/dist/src/classes/StringTable.js
+++ b/dist/src/classes/StringTable.js
@@ -126,8 +126,6 @@ class StringTable {
      * @returns {any} A string table row (tr).
      */
     makeStringRow(num, state, strTable) {
-        // The calling object
-        let caller = this;
         // State brand and type
         let stateBrand = state.strInfo.brand;
         let stateType = state.strInfo.type;
@@ -155,7 +153,7 @@ class StringTable {
         scaleLengthBox.type = 'text';
         scaleLengthBox.value = state.scaleLength.toString() + '"';
         // TODO: Make more efficient and eventually split into smaller functions.
-        scaleLengthBox.onchange = function () {
+        scaleLengthBox.onchange = (() => {
             let inputScale = scaleLengthBox.value.trim();
             // Temp: convert from mm to inches.
             let convertFromMillimeters = inputScale.substring(inputScale.length - 2) == 'mm';
@@ -180,38 +178,38 @@ class StringTable {
                     inputScale /= 25.4;
                 }
                 state.scaleLength = inputScale;
-                caller.render('str-table');
+                this.render('str-table');
             }
             // If it is not a number, just return the original value.
             else {
                 scaleLengthBox.value = state.scaleLength + '"';
             }
-        };
+        }).bind(this);
         scaleLength.appendChild(scaleLengthBox);
         let gaugeContainer = Utilities.createElement('div', 'gauge-buttons');
         let buttonGaugeDecrease = Utilities.createElement('button', `button-gauge decrease ${nullify}`, '-');
         let buttonGaugeIncrease = Utilities.createElement('button', `button-gauge increase ${nullify}`, '+');
         stringNum.appendChild(document.createTextNode(num.toString()));
-        buttonPitchDown.onclick = function () {
+        buttonPitchDown.onclick = (() => {
             state.shiftPitch(-1);
-            caller.render('str-table');
-        };
-        buttonPitchUp.onclick = function () {
+            this.render('str-table');
+        }).bind(this);
+        buttonPitchUp.onclick = (() => {
             state.shiftPitch(1);
-            caller.render('str-table');
-        };
+            this.render('str-table');
+        }).bind(this);
         // Increase gauge
-        buttonGaugeDecrease.onclick = function () {
+        buttonGaugeDecrease.onclick = (() => {
             let currentSeries = StringManager.getInstance().getSeriesByBrandAndType(stateBrand, stateType);
             state.strInfo = currentSeries.getPreviousString(state.strInfo);
-            caller.render('str-table');
-        };
+            this.render('str-table');
+        }).bind(this);
         // Decrease gauge
-        buttonGaugeIncrease.onclick = function () {
+        buttonGaugeIncrease.onclick = (() => {
             let currentSeries = StringManager.getInstance().getSeriesByBrandAndType(stateBrand, stateType);
             state.strInfo = currentSeries.getNextString(state.strInfo);
-            caller.render('str-table');
-        };
+            this.render('str-table');
+        }).bind(this);
         // Adding each field to the row, as well as the `note-inner` element to the 'Note' field
         for (let field of fields) {
             if (field.classList.contains('note-name')) {

--- a/dist/src/classes/StringTable.js
+++ b/dist/src/classes/StringTable.js
@@ -113,10 +113,102 @@ class StringTable {
             let strRow = this.makeStringRow(i + 1, this.getString(i), this);
             strTable.appendChild(strRow);
         }
-        // NOTE: Note the use of the non-null assertion operators here.
-        //       In its current form, the code will not compile without these.
         let tableElem = document.getElementById(tableId);
         tableElem.parentNode.replaceChild(strTable, tableElem);
+    }
+    /**
+     * Handles conversions on change of scale length input.
+     *
+     * @param scaleLengthBox
+     * @param state
+     */
+    onChangeInputScaleLength(scaleLengthBox, state) {
+        scaleLengthBox.type = 'text';
+        scaleLengthBox.value = state.scaleLength.toString() + '"';
+        scaleLengthBox.onchange = (() => {
+            let inputScale = scaleLengthBox.value.trim();
+            // Temp: convert from mm to inches.
+            let convertFromMillimeters = inputScale.substring(inputScale.length - 2) === 'mm';
+            // Easter Egg: convert feet to inches if a single tick is input.
+            let convertFromFeet = inputScale.charAt(inputScale.length - 1) == "'";
+            // Trim out units from string.
+            if (inputScale.charAt(inputScale.length - 1) === '"' || convertFromFeet) {
+                inputScale = inputScale.substring(0, inputScale.length - 1);
+            }
+            else if (convertFromMillimeters) {
+                inputScale = inputScale.substring(0, inputScale.length - 2).trim();
+            }
+            // Attempt to convert to number.
+            inputScale = Number.parseFloat(inputScale);
+            /*
+             * If it's a number, go ahead and set the scale and redraw the table.
+             * Otherwise, just return the original value.
+             */
+            if (typeof inputScale === 'number' && Number.isFinite(inputScale)) {
+                if (convertFromFeet) {
+                    inputScale *= 12;
+                }
+                if (convertFromMillimeters) {
+                    // TODO: A smart rounding system? (i.e. only if the value is very close to a certain fraction of an inch (e.g., 1/4th, 1/8th))
+                    inputScale /= 25.4;
+                }
+                state.scaleLength = inputScale;
+                this.render('str-table');
+            }
+            else {
+                scaleLengthBox.value = state.scaleLength + '"';
+            }
+        }).bind(this);
+    }
+    /**
+     * Handles button click to pitch down.
+     *
+     * @param buttonPitchDown
+     * @param state
+     */
+    onClickButtonPitchDown(buttonPitchDown, state) {
+        buttonPitchDown.onclick = (() => {
+            state.shiftPitch(-1);
+            this.render('str-table');
+        }).bind(this);
+    }
+    /**
+     * Handles button click to pitch up.
+     *
+     * @param buttonPitchUp
+     * @param state
+     */
+    onClickButtonPitchUp(buttonPitchUp, state) {
+        buttonPitchUp.onclick = (() => {
+            state.shiftPitch(1);
+            this.render('str-table');
+        }).bind(this);
+    }
+    /**
+     * Handles button click to decrease gauge.
+     *
+     * @param buttonGaugeDecrease
+     * @param state
+     */
+    onClickButtonDecreaseGauge(buttonGaugeDecrease, state) {
+        buttonGaugeDecrease.onclick = (() => {
+            let currentSeries = StringManager.getInstance().getSeriesByBrandAndType(state.strInfo.brand, state.strInfo.type);
+            state.strInfo = currentSeries.getPreviousString(state.strInfo);
+            this.render('str-table');
+        }).bind(this);
+    }
+    /**
+     * Handles button click to increase gauge.
+     *
+     * @param buttonGaugeIncrease
+     * @param state
+     */
+    onClickButtonIncreaseGauge(buttonGaugeIncrease, state) {
+        buttonGaugeIncrease.onclick = (() => {
+            let currentSeries = StringManager.getInstance().getSeriesByBrandAndType(state.strInfo.brand, state.strInfo.type);
+            state.strInfo = currentSeries.getPreviousString(state.strInfo);
+            this.render('str-table');
+        }).bind(this);
     }
     /**
      * Makes a row for a guitar string.
@@ -126,9 +218,6 @@ class StringTable {
      * @returns {any} A string table row (tr).
      */
     makeStringRow(num, state, strTable) {
-        // State brand and type
-        let stateBrand = state.strInfo.brand;
-        let stateType = state.strInfo.type;
         // If gauge buttons will have nullify class
         let nullify = this.canModifyGauge === false ? 'nullify' : '';
         // Array that will hold our fields/columns
@@ -150,66 +239,17 @@ class StringTable {
         let buttonPitchDown = Utilities.createElement('button', 'button-pitch down', '-');
         let buttonPitchUp = Utilities.createElement('button', 'button-pitch up', '+');
         let scaleLengthBox = Utilities.createElement('input', 'scale-length');
-        scaleLengthBox.type = 'text';
-        scaleLengthBox.value = state.scaleLength.toString() + '"';
-        // TODO: Make more efficient and eventually split into smaller functions.
-        scaleLengthBox.onchange = (() => {
-            let inputScale = scaleLengthBox.value.trim();
-            // Temp: convert from mm to inches.
-            let convertFromMillimeters = inputScale.substring(inputScale.length - 2) == 'mm';
-            // Easter Egg: convert feet to inches if a single tick is input.
-            let convertFromFeet = inputScale.charAt(inputScale.length - 1) == "'";
-            // Trim out units from string.
-            if (inputScale.charAt(inputScale.length - 1) == '"' || convertFromFeet) {
-                inputScale = inputScale.substring(0, inputScale.length - 1);
-            }
-            else if (convertFromMillimeters) {
-                inputScale = inputScale.substring(0, inputScale.length - 2).trim();
-            }
-            // Attempt to convert to number.
-            inputScale = Number.parseFloat(inputScale);
-            // If it is a number, go ahead and set the scale and redraw the table.
-            if (typeof inputScale == 'number' && Number.isFinite(inputScale)) {
-                if (convertFromFeet) {
-                    inputScale *= 12;
-                }
-                if (convertFromMillimeters) {
-                    // TODO: A smart rounding system? (i.e. only if the value is very close to a certain fraction of an inch (e.g., 1/4th, 1/8th))
-                    inputScale /= 25.4;
-                }
-                state.scaleLength = inputScale;
-                this.render('str-table');
-            }
-            // If it is not a number, just return the original value.
-            else {
-                scaleLengthBox.value = state.scaleLength + '"';
-            }
-        }).bind(this);
-        scaleLength.appendChild(scaleLengthBox);
         let gaugeContainer = Utilities.createElement('div', 'gauge-buttons');
-        let buttonGaugeDecrease = Utilities.createElement('button', `button-gauge decrease ${nullify}`, '-');
-        let buttonGaugeIncrease = Utilities.createElement('button', `button-gauge increase ${nullify}`, '+');
+        let buttonDecreaseGauge = Utilities.createElement('button', `button-gauge decrease ${nullify}`, '-');
+        let buttonIncreaseGauge = Utilities.createElement('button', `button-gauge increase ${nullify}`, '+');
+        scaleLength.appendChild(scaleLengthBox);
         stringNum.appendChild(document.createTextNode(num.toString()));
-        buttonPitchDown.onclick = (() => {
-            state.shiftPitch(-1);
-            this.render('str-table');
-        }).bind(this);
-        buttonPitchUp.onclick = (() => {
-            state.shiftPitch(1);
-            this.render('str-table');
-        }).bind(this);
-        // Increase gauge
-        buttonGaugeDecrease.onclick = (() => {
-            let currentSeries = StringManager.getInstance().getSeriesByBrandAndType(stateBrand, stateType);
-            state.strInfo = currentSeries.getPreviousString(state.strInfo);
-            this.render('str-table');
-        }).bind(this);
-        // Decrease gauge
-        buttonGaugeIncrease.onclick = (() => {
-            let currentSeries = StringManager.getInstance().getSeriesByBrandAndType(stateBrand, stateType);
-            state.strInfo = currentSeries.getNextString(state.strInfo);
-            this.render('str-table');
-        }).bind(this);
+        // Event handlers
+        this.onChangeInputScaleLength(scaleLengthBox, state);
+        this.onClickButtonPitchDown(buttonPitchDown, state);
+        this.onClickButtonPitchUp(buttonPitchUp, state);
+        this.onClickButtonDecreaseGauge(buttonDecreaseGauge, state);
+        this.onClickButtonIncreaseGauge(buttonIncreaseGauge, state);
         // Adding each field to the row, as well as the `note-inner` element to the 'Note' field
         for (let field of fields) {
             if (field.classList.contains('note-name')) {
@@ -224,8 +264,8 @@ class StringTable {
         buttonContainer.appendChild(buttonPitchDown);
         buttonContainer.appendChild(buttonPitchUp);
         gauge.appendChild(gaugeContainer);
-        gaugeContainer.appendChild(buttonGaugeDecrease);
-        gaugeContainer.appendChild(buttonGaugeIncrease);
+        gaugeContainer.appendChild(buttonDecreaseGauge);
+        gaugeContainer.appendChild(buttonIncreaseGauge);
         return tr;
     }
 }

--- a/script.js
+++ b/script.js
@@ -9,6 +9,6 @@ let jsonResult = Utilities.getJson('DAddario')
 window.onload = function() {
 	jsonResult
 		.then((res) => {
-			new Main(res).runTime()
+			new Main(res).run()
 		})
 }

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -111,7 +111,7 @@ class Main {
             }
         }
 
-        for (let i = 0; i < gaugeArray.length; ++i) {
+        for (let i = 0; i < weightsArray.length; ++i) {
             if (gaugeArray[i] && weightsArray[i]) {
                 stringObjects.push({ "gauge": gaugeArray[i], "unitWeight": weightsArray[i] })
             }
@@ -127,6 +127,7 @@ class Main {
         stringMin = 1
         stringDefault = stringMax > 6 ? 6 : stringMax
 
+        // Push each new StringInfo object
         for (let i = 0; i < stringObjects.length; i++) {
             stringCustomInfoArray.push(
                 new StringInfo(stringObjects[i].gauge, stringObjects[i].unitWeight, stringBrandValue, stringTypeValue
@@ -155,13 +156,13 @@ class Main {
 
         this.strTableManager.renderNumberInput(stringMin, stringMax, stringDefault)
         this.renderStringTable('str-table', 'num-strings')
-        this.handleNumberOfStringsInputOnChange()
+        this.onChangeInputNumberOfStrings()
     }
 
     /**
-     * Handle change in the input that modifies the number of strings displayed.
+     * Handles change that modifies the number of strings displayed.
      */
-    public handleNumberOfStringsInputOnChange() {
+    public onChangeInputNumberOfStrings() {
         const tables = this.strTableManager.stringTables
         const numberOfStringsInput = <HTMLInputElement>document.getElementById('num-strings')
 
@@ -175,31 +176,31 @@ class Main {
     }
 
     /**
-     * Handle click on the button to pitch down.
+     * Handles click to pitch all strings down.
      */
-    public handlePitchDownButtonOnClick() {
-        const buttonPitchDown = <HTMLInputElement>document.getElementsByClassName('button-pitches-decrease')[0]
+    public onClickButtonPitchesDown() {
+        const buttonPitchesDown = <HTMLInputElement>document.getElementsByClassName('button-pitches-decrease')[0]
 
-        buttonPitchDown.onclick = (() => {
+        buttonPitchesDown.onclick = (() => {
             this.renderPitchShifts(-1)
         }).bind(this)
     }
 
     /**
-     * Handle click on the button to pitch up.
+     * Handles click to pitch all strings up.
      */
-    public handlePitchUpButtonOnClick() {
-        const buttonPitchUp = <HTMLInputElement>document.getElementsByClassName('button-pitches-increase')[0]
+    public onClickButtonPitchesUp() {
+        const buttonPitchesUp = <HTMLInputElement>document.getElementsByClassName('button-pitches-increase')[0]
 
-        buttonPitchUp.onclick = (() => {
+        buttonPitchesUp.onclick = (() => {
             this.renderPitchShifts(1)
         }).bind(this)
     }
 
     /**
-     * Handle click for the custom instrument string submission.
+     * Handles click for the custom instrument string submission.
      */
-    public handleCustomStringSubmit() {
+    public onClickSubmitCustomString() {
         const customSubmit = <HTMLInputElement>document.getElementsByClassName('submit')[0]
 
         if (customSubmit) {
@@ -210,9 +211,9 @@ class Main {
     }
 
     /**
-     * Handle click for the custom instrument string interface exit.
+     * Handles click for the custom instrument string interface exit.
      */
-    public handleCustomStringExit() {
+    public onClickExitCustomString() {
         const customExit = <HTMLInputElement>document.getElementsByClassName('exit')[0]
 
         if (customExit) {
@@ -229,9 +230,9 @@ class Main {
     }
 
     /**
-     * Handle click on the button to add custom user-defined instrument strings.
+     * Handles button click to add custom user-defined instrument strings.
      */
-    public handleAddCustomStringsButtonOnClick() {
+    public onClickButtonAddCustomStrings() {
         const buttonAddCustomStrings = <HTMLInputElement>document.getElementsByClassName('add-custom-strings')[0]
 
         buttonAddCustomStrings.onclick = (() => {
@@ -246,8 +247,8 @@ class Main {
             }
 
             // Handle clicks on submit or exit
-            this.handleCustomStringSubmit()
-            this.handleCustomStringExit()
+            this.onClickSubmitCustomString()
+            this.onClickExitCustomString()
 
         }).bind(this)
     }
@@ -262,10 +263,10 @@ class Main {
         }
 
         // Event handlers
-        this.handleNumberOfStringsInputOnChange()
-        this.handlePitchDownButtonOnClick()
-        this.handlePitchUpButtonOnClick()
-        this.handleAddCustomStringsButtonOnClick()
+        this.onChangeInputNumberOfStrings()
+        this.onClickButtonPitchesDown()
+        this.onClickButtonPitchesUp()
+        this.onClickButtonAddCustomStrings()
 
         // Table render
         this.renderStringTable('str-table', 'num-strings')

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -48,12 +48,14 @@ class Main {
      * @param {number} semitones A semitone count.
      */
     public renderPitchShifts(semitones: number) {
-        for (let i = 0; i < this.strTableManager.stringTables.length; i++) {
-            if (this.strTableManager.stringTables[i].isCurrent) {
-                this.strTableManager.stringTables[i].shiftPitches(semitones)
-                this.strTableManager.stringTables[i].render('str-table')
+        const tables = this.strTableManager.stringTables
+
+        tables.forEach((table, i) => {
+            if (table.isCurrent) {
+                tables[i].shiftPitches(semitones)
+                tables[i].render('str-table')
             }
-        }
+        })
     }
 
     /**
@@ -63,20 +65,22 @@ class Main {
      * @param {string} numberId The id for the `Number of Strings` input element.
      */
     public renderStringTable(tableId: string, numberId: string) {
-        let numStrings = (<HTMLInputElement>document.getElementById(numberId)).value!
+        const tables = this.strTableManager.stringTables
+        const numStrings = (<HTMLInputElement>document.getElementById(numberId)).value!
 
-        for (let i = 0; i < this.strTableManager.stringTables.length; i++) {
-            if (this.strTableManager.stringTables[i].isCurrent) {
-                this.strTableManager.stringTables[i].setNumStrings(Number(numStrings))
-                this.strTableManager.stringTables[i].render(tableId)
+        tables.forEach((table, i) => {
+            if (table.isCurrent) {
+                tables[i].setNumStrings(Number(numStrings))
+                tables[i].render(tableId)
             }
-        }
+        })
     }
 
     /**
      * Submit function for the custom string data.
      */
     public submitCustomStringData() {
+        const tables = this.strTableManager.stringTables
         const overlay = <HTMLInputElement>document.getElementsByClassName('overlay')[0]
         const stringBrandValue = (<HTMLInputElement>document.getElementsByClassName('custom-string-brand')[0]).value
         const stringTypeValue = (<HTMLInputElement>document.getElementsByClassName('custom-string-type')[0]).value
@@ -89,7 +93,7 @@ class Main {
         let weightsArray = []
         let stringObjects = []
         let stringCustomInfoArray = []
-
+        
         // NOTE: Add logic to validate entries on submission
         for (let gauge of stringGauges) {
             let gaugeValue = (gauge as HTMLInputElement).value
@@ -130,17 +134,17 @@ class Main {
         }
 
         // Push a new string table
-        this.strTableManager.stringTables.push(new StringTable(StringManager.getInstance().getStandardTuning(stringCustomInfoArray)))
+        tables.push(new StringTable(StringManager.getInstance().getStandardTuning(stringCustomInfoArray)))
 
         // Set the new string table as the current
-        for (let i = 0; i < this.strTableManager.stringTables.length; i++) {
-            if (i === this.strTableManager.stringTables.length - 1) {
-                this.strTableManager.stringTables[i].canModifyGauge = false
-                this.strTableManager.stringTables[i].isCurrent = true
+        for (let i = 0; i < tables.length; i++) {
+            if (i === tables.length - 1) {
+                tables[i].canModifyGauge = false
+                tables[i].isCurrent = true
                 continue
             }
 
-            this.strTableManager.stringTables[i].isCurrent = false
+            tables[i].isCurrent = false
         }
 
         overlay.classList.replace('show', 'hide')
@@ -158,11 +162,12 @@ class Main {
      * Handle change in the input that modifies the number of strings displayed.
      */
     public handleNumberOfStringsInputOnChange() {
+        const tables = this.strTableManager.stringTables
         const numberOfStringsInput = <HTMLInputElement>document.getElementById('num-strings')
 
         numberOfStringsInput.onchange = (() => {
-            for (let i = 0; i < this.strTableManager.stringTables.length; i++) {
-                if (this.strTableManager.stringTables[i].isCurrent) {
+            for (let i = 0; i < tables.length; i++) {
+                if (tables[i].isCurrent) {
                     this.renderStringTable('str-table', 'num-strings');
                 }
             }

--- a/src/Main.ts
+++ b/src/Main.ts
@@ -64,7 +64,7 @@ class Main {
      */
     public renderStringTable(tableId: string, numberId: string) {
         let numStrings = (<HTMLInputElement>document.getElementById(numberId)).value!
-        
+
         for (let i = 0; i < this.strTableManager.stringTables.length; i++) {
             if (this.strTableManager.stringTables[i].isCurrent) {
                 this.strTableManager.stringTables[i].setNumStrings(Number(numStrings))
@@ -84,7 +84,7 @@ class Main {
         const stringWeights = <HTMLCollectionOf<Element>>document.getElementsByClassName('custom-string-weight')
 
         let stringMin, stringMax, stringDefault
-        
+
         let gaugeArray = []
         let weightsArray = []
         let stringObjects = []
@@ -101,7 +101,7 @@ class Main {
 
         for (let weight of stringWeights) {
             let weightValue = (weight as HTMLInputElement).value
-            
+
             if (weightValue) {
                 weightsArray.push(Number(weightValue))
             }
@@ -109,7 +109,7 @@ class Main {
 
         for (let i = 0; i < gaugeArray.length; ++i) {
             if (gaugeArray[i] && weightsArray[i]) {
-                stringObjects.push({"gauge": gaugeArray[i], "unitWeight": weightsArray[i]})
+                stringObjects.push({ "gauge": gaugeArray[i], "unitWeight": weightsArray[i] })
             }
         }
 
@@ -117,7 +117,7 @@ class Main {
         if (!stringBrandValue || !stringTypeValue || stringObjects.length === 0) {
             return
         }
-        
+
         // Assign our variables for the input of type 'number'
         stringMax = stringObjects.length
         stringMin = 1
@@ -128,10 +128,10 @@ class Main {
                 new StringInfo(stringObjects[i].gauge, stringObjects[i].unitWeight, stringBrandValue, stringTypeValue
             ))
         }
-        
+
         // Push a new string table
         this.strTableManager.stringTables.push(new StringTable(StringManager.getInstance().getStandardTuning(stringCustomInfoArray)))
-        
+
         // Set the new string table as the current
         for (let i = 0; i < this.strTableManager.stringTables.length; i++) {
             if (i === this.strTableManager.stringTables.length - 1) {
@@ -144,63 +144,92 @@ class Main {
         }
 
         overlay.classList.replace('show', 'hide')
-        
+
         setTimeout(() => {
             overlay.style.display = 'none'
         }, 500);
 
         this.strTableManager.renderNumberInput(stringMin, stringMax, stringDefault)
         this.renderStringTable('str-table', 'num-strings')
-
-        // TODO: Works, but is pretty ugly and should be refactored. This is a repetition of an onchange event handler that
-        //       is used in runTime(), which itself no longer points to the original element after it is removed from the DOM.
-        const numStrings = <HTMLInputElement>document.getElementById('num-strings')
-        const caller = this
-
-        numStrings.onchange = function() {
-            for (let i = 0; i < caller.strTableManager.stringTables.length; i++) {
-                if (caller.strTableManager.stringTables[i].isCurrent) {
-                    caller.renderStringTable('str-table', 'num-strings');
-                }
-            }
-        }
-	}
+        this.handleNumberOfStringsInputOnChange()
+    }
 
     /**
-     * Run time!
+     * Handle change in the input that modifies the number of strings displayed.
      */
-    public runTime() {
-        const caller = this
-        
-        // Render our input (type 'number') first
-        if (!document.getElementsByClassName('number-of-strings')[0]) {
-            caller.strTableManager.renderNumberInput()
-        }
-  
-        // Some of our elements to be used
+    public handleNumberOfStringsInputOnChange() {
         const numberOfStringsInput = <HTMLInputElement>document.getElementById('num-strings')
-        const buttonAddCustomStrings = <HTMLInputElement>document.getElementsByClassName('add-custom-strings')[0]
-        const buttonPitchDown = <HTMLInputElement>document.getElementsByClassName('button-pitches-decrease')[0]
-        const buttonPitchUp = <HTMLInputElement>document.getElementsByClassName('button-pitches-increase')[0]
-        
-        // Events
-        numberOfStringsInput.onchange = function () {
-            for (let i = 0; i < caller.strTableManager.stringTables.length; i++) {
-                if (caller.strTableManager.stringTables[i].isCurrent) {
-                    caller.renderStringTable('str-table', 'num-strings');
+
+        numberOfStringsInput.onchange = (() => {
+            for (let i = 0; i < this.strTableManager.stringTables.length; i++) {
+                if (this.strTableManager.stringTables[i].isCurrent) {
+                    this.renderStringTable('str-table', 'num-strings');
                 }
             }
-        }
+        }).bind(this)
+    }
 
-        buttonPitchDown.onclick = function() {
-            caller.renderPitchShifts(-1)
-        }
+    /**
+     * Handle click on the button to pitch down.
+     */
+    public handlePitchDownButtonOnClick() {
+        const buttonPitchDown = <HTMLInputElement>document.getElementsByClassName('button-pitches-decrease')[0]
 
-        buttonPitchUp.onclick = function() {
-            caller.renderPitchShifts(1)
-        }
+        buttonPitchDown.onclick = (() => {
+            this.renderPitchShifts(-1)
+        }).bind(this)
+    }
 
-        buttonAddCustomStrings.onclick = function() {
+    /**
+     * Handle click on the button to pitch up.
+     */
+    public handlePitchUpButtonOnClick() {
+        const buttonPitchUp = <HTMLInputElement>document.getElementsByClassName('button-pitches-increase')[0]
+
+        buttonPitchUp.onclick = (() => {
+            this.renderPitchShifts(1)
+        }).bind(this)
+    }
+
+    /**
+     * Handle click for the custom instrument string submission.
+     */
+    public handleCustomStringSubmit() {
+        const customSubmit = <HTMLInputElement>document.getElementsByClassName('submit')[0]
+
+        if (customSubmit) {
+            customSubmit.onclick = (() => {
+                this.submitCustomStringData()
+            }).bind(this)
+        }
+    }
+
+    /**
+     * Handle click for the custom instrument string interface exit.
+     */
+    public handleCustomStringExit() {
+        const customExit = <HTMLInputElement>document.getElementsByClassName('exit')[0]
+
+        if (customExit) {
+            customExit.onclick = (() => {
+                const overlay = <HTMLInputElement>document.getElementsByClassName('overlay')[0]
+
+                overlay.classList.replace('show', 'hide')
+
+                setTimeout(() => {
+                    overlay.style.display = 'none'
+                }, 500);
+            })
+        }
+    }
+
+    /**
+     * Handle click on the button to add custom user-defined instrument strings.
+     */
+    public handleAddCustomStringsButtonOnClick() {
+        const buttonAddCustomStrings = <HTMLInputElement>document.getElementsByClassName('add-custom-strings')[0]
+
+        buttonAddCustomStrings.onclick = (() => {
             const overlay = <HTMLInputElement>document.getElementsByClassName('overlay')[0]
 
             if (overlay) {
@@ -208,32 +237,32 @@ class Main {
                 overlay.classList.replace('hide', 'show')
             }
             else {
-                caller.renderStringCustomInput()
+                this.renderStringCustomInput()
             }
 
-            // Watch for click on exit or submit
-            const customSubmit = <HTMLInputElement>document.getElementsByClassName('submit')[0]
-            const customExit = <HTMLInputElement>document.getElementsByClassName('exit')[0]
+            // Handle clicks on submit or exit
+            this.handleCustomStringSubmit()
+            this.handleCustomStringExit()
 
-            if (customSubmit) {
-                customSubmit.onclick = function() {
-                    caller.submitCustomStringData()
-                }
-            }
+        }).bind(this)
+    }
 
-            if (customExit) {
-                customExit.onclick = function() {
-                    const overlay = <HTMLInputElement>document.getElementsByClassName('overlay')[0]
-                    
-                    overlay.classList.replace('show', 'hide')
-
-                    setTimeout(() => {
-                        overlay.style.display = 'none'
-                    }, 500);
-                }
-            }
+    /**
+     * Run time!
+     */
+    public run() {
+        // Render our input of type number first
+        if (!document.getElementsByClassName('number-of-strings')[0]) {
+            this.strTableManager.renderNumberInput()
         }
 
-        caller.renderStringTable('str-table', 'num-strings')
+        // Event handlers
+        this.handleNumberOfStringsInputOnChange()
+        this.handlePitchDownButtonOnClick()
+        this.handlePitchUpButtonOnClick()
+        this.handleAddCustomStringsButtonOnClick()
+
+        // Table render
+        this.renderStringTable('str-table', 'num-strings')
     }
 }

--- a/src/classes/StringTable.ts
+++ b/src/classes/StringTable.ts
@@ -160,9 +160,6 @@ class StringTable {
      * @returns {any} A string table row (tr).
      */
     public makeStringRow(num: number, state: StringState, strTable: StringTable): any {
-        // The calling object
-        let caller = this
-
         // State brand and type
         let stateBrand = state.strInfo.brand
         let stateType = state.strInfo.type
@@ -197,7 +194,7 @@ class StringTable {
         scaleLengthBox.value = state.scaleLength.toString() + '"'
 
         // TODO: Make more efficient and eventually split into smaller functions.
-        scaleLengthBox.onchange = function () {
+        scaleLengthBox.onchange = (() => {
             let inputScale = scaleLengthBox.value.trim()
 
             // Temp: convert from mm to inches.
@@ -228,13 +225,13 @@ class StringTable {
                 }
 
                 state.scaleLength = inputScale
-                caller.render('str-table')
+                this.render('str-table')
             }
             // If it is not a number, just return the original value.
             else {
                 scaleLengthBox.value = state.scaleLength + '"'
             }
-        }
+        }).bind(this)
 
         scaleLength.appendChild(scaleLengthBox)
 
@@ -244,33 +241,33 @@ class StringTable {
 
         stringNum.appendChild(document.createTextNode(num.toString()))
 
-        buttonPitchDown.onclick = function () {
+        buttonPitchDown.onclick = (() => {
             state.shiftPitch(-1)
-            caller.render('str-table')
-        }
+            this.render('str-table')
+        }).bind(this)
 
-        buttonPitchUp.onclick = function () {
+        buttonPitchUp.onclick = (() => {
             state.shiftPitch(1)
-            caller.render('str-table')
-        }
+            this.render('str-table')
+        }).bind(this)
 
         // Increase gauge
-        buttonGaugeDecrease.onclick = function () {
+        buttonGaugeDecrease.onclick = (() => {
             let currentSeries = StringManager.getInstance().getSeriesByBrandAndType(stateBrand, stateType)
 
             state.strInfo = currentSeries.getPreviousString(state.strInfo)
 
-            caller.render('str-table')
-        }
+            this.render('str-table')
+        }).bind(this)
 
         // Decrease gauge
-        buttonGaugeIncrease.onclick = function () {
+        buttonGaugeIncrease.onclick = (() => {
             let currentSeries = StringManager.getInstance().getSeriesByBrandAndType(stateBrand, stateType)
 
             state.strInfo = currentSeries.getNextString(state.strInfo)
 
-            caller.render('str-table')
-        }
+            this.render('str-table')
+        }).bind(this)
 
         // Adding each field to the row, as well as the `note-inner` element to the 'Note' field
         for (let field of fields) {


### PR DESCRIPTION
Refactored many event handlers into their own methods, specifically within `Main` and `StringTable`.

The purpose of this was to first remove the use of `caller` and instead bind `this` to the anonymous functions that run when each of these events is handled. 

Second, it functions to separate each of the handlers into their own scopes, and makes it clearer/cleaner for the methods that use them.

Some other refactoring was done as well, e.g. naming for stringTable uses within `Main`.