### PR TITLE
 Select type of string per string row in table.

### DIFF
--- a/dist/src/classes/StringManager.js
+++ b/dist/src/classes/StringManager.js
@@ -71,4 +71,25 @@ class StringManager {
         }
         return new StringSeries("Undefined", "Guitar String", []);
     }
+    /**
+     * Gets the number of series objects we manage.
+     *
+     * @returns The number of series objects we manage.
+     */
+    getNumberOfSeries() {
+        return this._stringSeries.length;
+    }
+    /**
+     * Gets a series by its index.
+     *
+     * @param {number} index The index of the desired string series object.
+     * @returns A string series at the given index if it exists, otherwise undefined.
+     */
+    getSeriesByIndex(index) {
+        // Return undefined if out of bounds.
+        if (index < 0 || index >= this._stringSeries.length) {
+            return undefined;
+        }
+        return this._stringSeries[index];
+    }
 }

--- a/dist/src/classes/StringSeries.js
+++ b/dist/src/classes/StringSeries.js
@@ -43,12 +43,12 @@ class StringSeries {
      * Returns the string matching or nearest to the input gauge.
      *
      * @param {number} gauge The gauge to search for.
-     * @returns {StringInfo} A string matching that gauge or the nearest gauge (default for nearest: middle gauge).
+     * @returns {StringInfo} A string matching that gauge or the nearest gauge.
      */
     getStringByGauge(gauge) {
         const last = this.strings[this.strings.length - 1];
         const first = this.strings[0];
-        let prev, curr, nearest = this.strings[Math.trunc((this.strings.length - 1) / 2)];
+        let prev, curr, nearest;
         // Check our first and last gauge immediately, primarily in case our gauge is out-of-range.
         if (gauge <= first.gauge) {
             return first;

--- a/dist/src/classes/StringSeries.js
+++ b/dist/src/classes/StringSeries.js
@@ -40,19 +40,37 @@ class StringSeries {
         this.strings.forEach((str) => str.type = this.type);
     }
     /**
-     * Returns the first string matching the input gauge.
+     * Returns the string matching or nearest to the input gauge.
      *
      * @param {number} gauge The gauge to search for.
-     * @returns {StringInfo} A string matching that gauge, or else the middle string in the series.
+     * @returns {StringInfo} A string matching that gauge or the nearest gauge (default for nearest: middle gauge).
      */
     getStringByGauge(gauge) {
-        const last = this.strings.length - 1;
-        for (const i in this.strings) {
+        const last = this.strings[this.strings.length - 1];
+        const first = this.strings[0];
+        let prev, curr, nearest = this.strings[Math.trunc((this.strings.length - 1) / 2)];
+        // Check our first and last gauge immediately, primarily in case our gauge is out-of-range.
+        if (gauge <= first.gauge) {
+            return first;
+        }
+        if (gauge >= last.gauge) {
+            return last;
+        }
+        /*
+         * Returning the match or else simply getting the nearest value.
+         * Only checking second index through second-to-last index as we have already checked first/last.
+         */
+        for (let i = 1; i < this.strings.length - 1; i++) {
             if (this.strings[i].gauge === gauge) {
                 return this.strings[i];
             }
+            prev = this.strings[i - 1];
+            curr = this.strings[i];
+            if (Math.abs(gauge - curr.gauge) < Math.abs(gauge - prev.gauge)) {
+                nearest = curr;
+            }
         }
-        return this.strings[Math.trunc(last / 2)];
+        return nearest;
     }
     /**
      * Gets the string before the input string in the series.

--- a/dist/src/classes/StringTable.js
+++ b/dist/src/classes/StringTable.js
@@ -1,3 +1,4 @@
+import { StringManager } from "./StringManager.js";
 import { StringStateCollection } from "./StringStateCollection.js";
 import { TableRenders } from "../renders/TableRenders.js";
 import { TableEvents } from "../events/TableEvents.js";
@@ -122,7 +123,7 @@ class StringTable {
         let noteLetter = Utilities.createElement('span', 'note-letter', Note.getNoteLetter(state.note));
         let noteOctave = Utilities.createElement('sub', 'note-octave', Note.getNoteOctave(state.note));
         let scaleLength = Utilities.createElement('td', 'scale-length');
-        let stringType = Utilities.createElement('td', 'string-type', state.strInfo.brand + ' ' + state.strInfo.type);
+        let stringType = Utilities.createElement('td', 'string-type');
         let gauge = Utilities.createElement('td', 'gauge', state.strInfo.gauge * 1000);
         let tension = Utilities.createElement('td', 'tension', state.calculateStringTension());
         // Pushing the elements that constitute our fields (the columns)
@@ -158,6 +159,31 @@ class StringTable {
         gauge.appendChild(gaugeContainer);
         gaugeContainer.appendChild(buttonDecreaseGauge);
         gaugeContainer.appendChild(buttonIncreaseGauge);
+        // Adding select box for the string type.
+        let typeSelectBox = Utilities.createElement('select', `string-type-selector ${nullify}`);
+        // Add a dummy box with just one option if we are currently using custom strings.
+        if (this.canModifyGauge === false) {
+            let optionTest = Utilities.createElement('option', 'string-type', state.strInfo.brand + ' ' + state.strInfo.type);
+            typeSelectBox.add(optionTest);
+        }
+        // Otherwise, add a box with all string series values.
+        else {
+            for (let i = 0; i < StringManager.getInstance().getNumberOfSeries(); i++) {
+                let series = StringManager.getInstance().getSeriesByIndex(i);
+                if (series === undefined) {
+                    console.error(`StringSeries at index ${i} is undefined.`);
+                    continue;
+                }
+                let option = Utilities.createElement('option', 'string-type', series.brand + ' ' + series.type);
+                option.value = series.brand + ";" + series.type;
+                typeSelectBox.add(option);
+                if (series.brand === state.strInfo.brand && series.type === state.strInfo.type) {
+                    typeSelectBox.selectedIndex = i;
+                }
+            }
+        }
+        this.handles.onChangeStringType(typeSelectBox, state);
+        stringType.appendChild(typeSelectBox);
         return tr;
     }
 }

--- a/dist/src/classes/StringTable.js
+++ b/dist/src/classes/StringTable.js
@@ -161,12 +161,14 @@ class StringTable {
         gaugeContainer.appendChild(buttonIncreaseGauge);
         // Adding select box for the string type.
         let typeSelectBox = Utilities.createElement('select', `string-type-selector ${nullify}`);
-        // Add a dummy box with just one option if we are currently using custom strings.
+        /*
+         * Add a dummy box with just one option if we are currently using custom strings.
+         * Otherwise, add a box with all string series values.
+         */
         if (this.canModifyGauge === false) {
             let optionTest = Utilities.createElement('option', 'string-type', state.strInfo.brand + ' ' + state.strInfo.type);
             typeSelectBox.add(optionTest);
         }
-        // Otherwise, add a box with all string series values.
         else {
             for (let i = 0; i < StringManager.getInstance().getNumberOfSeries(); i++) {
                 let series = StringManager.getInstance().getSeriesByIndex(i);

--- a/dist/src/events/TableEvents.js
+++ b/dist/src/events/TableEvents.js
@@ -107,4 +107,19 @@ class TableEvents {
             this.renders.table('str-table');
         }).bind(this);
     }
+    /**
+     * Handles changes to the selected string type.
+     *
+     * @param typeSelectBox The select box for choosing the string brand/type.
+     * @param state The string state to modify.
+     */
+    onChangeStringType(typeSelectBox, state) {
+        typeSelectBox.onchange = (() => {
+            let index = typeSelectBox.selectedIndex;
+            let option = typeSelectBox.options[index].value.split(";");
+            let series = StringManager.getInstance().getSeriesByBrandAndType(option[0], option[1]);
+            state.strInfo = series.getStringByGauge(state.strInfo.gauge);
+            this.renders.table('str-table');
+        }).bind(this);
+    }
 }

--- a/src/classes/StringManager.ts
+++ b/src/classes/StringManager.ts
@@ -93,4 +93,27 @@ class StringManager {
 
         return new StringSeries("Undefined", "Guitar String", [])
     }
+
+    /**
+     * Gets the number of series objects we manage.
+     * 
+     * @returns The number of series objects we manage.
+     */
+    public getNumberOfSeries(): number {
+        return this._stringSeries.length
+    }
+
+    /**
+     * Gets a series by its index.
+     * 
+     * @param {number} index The index of the desired string series object. 
+     * @returns A string series at the given index if it exists, otherwise undefined.
+     */
+    public getSeriesByIndex(index: number): StringSeries | undefined {
+        // Return undefined if out of bounds.
+        if (index < 0 || index >= this._stringSeries.length) {
+            return undefined
+        }
+        return this._stringSeries[index]
+    }
 }

--- a/src/classes/StringSeries.ts
+++ b/src/classes/StringSeries.ts
@@ -59,13 +59,13 @@ class StringSeries implements StringMake {
      * Returns the string matching or nearest to the input gauge.
      *
      * @param {number} gauge The gauge to search for.
-     * @returns {StringInfo} A string matching that gauge or the nearest gauge (default for nearest: middle gauge).
+     * @returns {StringInfo} A string matching that gauge or the nearest gauge.
      */
     public getStringByGauge(gauge: number): StringInfo {
         const last = this.strings[this.strings.length - 1]
         const first = this.strings[0]
 
-        let prev, curr, nearest = this.strings[Math.trunc((this.strings.length - 1) / 2)]
+        let prev, curr, nearest
 
         // Check our first and last gauge immediately, primarily in case our gauge is out-of-range.
         if (gauge <= first.gauge) {
@@ -93,7 +93,7 @@ class StringSeries implements StringMake {
             }
         }
 
-        return nearest
+        return nearest!
     }
 
     /**

--- a/src/classes/StringSeries.ts
+++ b/src/classes/StringSeries.ts
@@ -56,21 +56,44 @@ class StringSeries implements StringMake {
     }
 
     /**
-     * Returns the first string matching the input gauge.
+     * Returns the string matching or nearest to the input gauge.
      *
      * @param {number} gauge The gauge to search for.
-     * @returns {StringInfo} A string matching that gauge, or else the middle string in the series.
+     * @returns {StringInfo} A string matching that gauge or the nearest gauge (default for nearest: middle gauge).
      */
     public getStringByGauge(gauge: number): StringInfo {
-        const last = this.strings.length - 1
+        const last = this.strings[this.strings.length - 1]
+        const first = this.strings[0]
 
-        for (const i in this.strings) {
+        let prev, curr, nearest = this.strings[Math.trunc((this.strings.length - 1) / 2)]
+
+        // Check our first and last gauge immediately, primarily in case our gauge is out-of-range.
+        if (gauge <= first.gauge) {
+            return first
+        }
+
+        if (gauge >= last.gauge) {
+            return last
+        }
+
+        /* 
+         * Returning the match or else simply getting the nearest value.
+         * Only checking second index through second-to-last index as we have already checked first/last.
+         */
+        for (let i = 1; i < this.strings.length - 1; i++) {
             if (this.strings[i].gauge === gauge) {
                 return this.strings[i]
             }
+
+            prev = this.strings[i  - 1]
+            curr = this.strings[i]
+        
+            if (Math.abs(gauge - curr.gauge) < Math.abs(gauge - prev.gauge)) {
+                nearest = curr
+            }
         }
 
-        return this.strings[Math.trunc(last / 2)]
+        return nearest
     }
 
     /**

--- a/src/classes/StringTable.ts
+++ b/src/classes/StringTable.ts
@@ -1,3 +1,5 @@
+import { StringManager } from  "./StringManager.js"
+import { StringSeries } from "./StringSeries.js"
 import { StringState } from "./StringState.js"
 import { StringStateCollection } from "./StringStateCollection.js"
 import { StringSetEnum } from "../enums/StringSetEnum.js"
@@ -158,7 +160,7 @@ class StringTable {
         let noteLetter = Utilities.createElement('span', 'note-letter', Note.getNoteLetter(state.note))
         let noteOctave = Utilities.createElement('sub', 'note-octave', Note.getNoteOctave(state.note))
         let scaleLength = Utilities.createElement('td', 'scale-length')
-        let stringType = Utilities.createElement('td', 'string-type', state.strInfo.brand + ' ' + state.strInfo.type)
+        let stringType = Utilities.createElement('td', 'string-type')
         let gauge = Utilities.createElement('td', 'gauge', state.strInfo.gauge * 1000)
         let tension = Utilities.createElement('td', 'tension', state.calculateStringTension())
 
@@ -202,6 +204,32 @@ class StringTable {
         gauge.appendChild(gaugeContainer)
         gaugeContainer.appendChild(buttonDecreaseGauge)
         gaugeContainer.appendChild(buttonIncreaseGauge)
+
+        // Adding select box for the string type.
+        let typeSelectBox = Utilities.createElement('select', `string-type-selector ${nullify}`)
+        // Add a dummy box with just one option if we are currently using custom strings.
+        if (this.canModifyGauge === false) {
+            let optionTest = Utilities.createElement('option', 'string-type', state.strInfo.brand + ' ' + state.strInfo.type)
+            typeSelectBox.add(optionTest)
+        }
+        // Otherwise, add a box with all string series values.
+        else {
+            for (let i = 0; i < StringManager.getInstance().getNumberOfSeries(); i++) {
+                let series: StringSeries | undefined = StringManager.getInstance().getSeriesByIndex(i)
+                if (series === undefined) {
+                    console.error(`StringSeries at index ${i} is undefined.`)
+                    continue
+                }
+                let option = Utilities.createElement('option', 'string-type', series.brand + ' ' + series.type)
+                option.value = series.brand + ";" + series.type
+                typeSelectBox.add(option)
+                if (series.brand === state.strInfo.brand && series.type === state.strInfo.type) {
+                    typeSelectBox.selectedIndex = i
+                }
+            }
+        }
+        this.handles.onChangeStringType(typeSelectBox, state)
+        stringType.appendChild(typeSelectBox)
 
         return tr
     }

--- a/src/classes/StringTable.ts
+++ b/src/classes/StringTable.ts
@@ -207,27 +207,35 @@ class StringTable {
 
         // Adding select box for the string type.
         let typeSelectBox = Utilities.createElement('select', `string-type-selector ${nullify}`)
-        // Add a dummy box with just one option if we are currently using custom strings.
+
+        /* 
+         * Add a dummy box with just one option if we are currently using custom strings.
+         * Otherwise, add a box with all string series values.
+         */
         if (this.canModifyGauge === false) {
             let optionTest = Utilities.createElement('option', 'string-type', state.strInfo.brand + ' ' + state.strInfo.type)
             typeSelectBox.add(optionTest)
         }
-        // Otherwise, add a box with all string series values.
         else {
             for (let i = 0; i < StringManager.getInstance().getNumberOfSeries(); i++) {
                 let series: StringSeries | undefined = StringManager.getInstance().getSeriesByIndex(i)
+        
                 if (series === undefined) {
                     console.error(`StringSeries at index ${i} is undefined.`)
                     continue
                 }
+
                 let option = Utilities.createElement('option', 'string-type', series.brand + ' ' + series.type)
+
                 option.value = series.brand + ";" + series.type
                 typeSelectBox.add(option)
+
                 if (series.brand === state.strInfo.brand && series.type === state.strInfo.type) {
                     typeSelectBox.selectedIndex = i
                 }
             }
         }
+        
         this.handles.onChangeStringType(typeSelectBox, state)
         stringType.appendChild(typeSelectBox)
 

--- a/src/events/TableEvents.ts
+++ b/src/events/TableEvents.ts
@@ -142,6 +142,7 @@ class TableEvents {
             let index = typeSelectBox.selectedIndex
             let option: string[] = typeSelectBox.options[index].value.split(";")
             let series: StringSeries = StringManager.getInstance().getSeriesByBrandAndType(option[0], option[1])
+
             state.strInfo = series.getStringByGauge(state.strInfo.gauge)
             this.renders.table('str-table')
         }).bind(this)

--- a/src/events/TableEvents.ts
+++ b/src/events/TableEvents.ts
@@ -134,7 +134,7 @@ class TableEvents {
     /**
      * Handles changes to the selected string type.
      * 
-     * @param typeSelectBox The select box that
+     * @param typeSelectBox The select box for choosing the string brand/type.
      * @param state The string state to modify.
      */
     public onChangeStringType(typeSelectBox: any, state: StringState) {
@@ -142,7 +142,7 @@ class TableEvents {
             let index = typeSelectBox.selectedIndex
             let option: string[] = typeSelectBox.options[index].value.split(";")
             let series: StringSeries = StringManager.getInstance().getSeriesByBrandAndType(option[0], option[1])
-            console.log("Series:", series)
+console.log("Series:", series)
             state.strInfo = series.getStringByGauge(state.strInfo.gauge)
             this.renders.table('str-table')
         }).bind(this)

--- a/src/events/TableEvents.ts
+++ b/src/events/TableEvents.ts
@@ -1,4 +1,5 @@
 import { StringManager } from "../classes/StringManager.js"
+import { StringSeries } from "../classes/StringSeries.js"
 import { StringState } from "../classes/StringState.js"
 import { TableRenders } from "../renders/TableRenders.js"
 
@@ -126,6 +127,23 @@ class TableEvents {
             let currentSeries = StringManager.getInstance().getSeriesByBrandAndType(state.strInfo.brand, state.strInfo.type)
 
             state.strInfo = currentSeries.getNextString(state.strInfo)
+            this.renders.table('str-table')
+        }).bind(this)
+    }
+
+    /**
+     * Handles changes to the selected string type.
+     * 
+     * @param typeSelectBox The select box that
+     * @param state The string state to modify.
+     */
+    public onChangeStringType(typeSelectBox: any, state: StringState) {
+        typeSelectBox.onchange = (() => {
+            let index = typeSelectBox.selectedIndex
+            let option: string[] = typeSelectBox.options[index].value.split(";")
+            let series: StringSeries = StringManager.getInstance().getSeriesByBrandAndType(option[0], option[1])
+            console.log("Series:", series)
+            state.strInfo = series.getStringByGauge(state.strInfo.gauge)
             this.renders.table('str-table')
         }).bind(this)
     }

--- a/src/events/TableEvents.ts
+++ b/src/events/TableEvents.ts
@@ -142,7 +142,6 @@ class TableEvents {
             let index = typeSelectBox.selectedIndex
             let option: string[] = typeSelectBox.options[index].value.split(";")
             let series: StringSeries = StringManager.getInstance().getSeriesByBrandAndType(option[0], option[1])
-console.log("Series:", series)
             state.strInfo = series.getStringByGauge(state.strInfo.gauge)
             this.renders.table('str-table')
         }).bind(this)


### PR DESCRIPTION
A select box replaces the static string brand/type (e.g., _D'Addario Plain Steel_). Any string series (brand/type) can be selected via this drop-down box. When a different string series object is selected, it calls the `getStringByGauge` function with the same gauge as currently selected. If the old gauge is present in the new `StringSeries`, it will use it as the new string.

If the old gauge is not present in the new string series, it currently selects the middle `StringInfo` object of that series. This should be changed to select the closest gauge present in that set in the future once some refactoring is done.

If custom strings have been entered, the select box appears nullified and has the static brand/type entered in the custom string form.